### PR TITLE
Use a better warning style

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 ![PyPI Version](https://img.shields.io/pypi/v/LovelyPlots.svg) ![PyPI Downloads](https://static.pepy.tech/badge/LovelyPlots) [![doi](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.6903937-blue)](
 http://doi.org/10.5281/zenodo.6903937) ![tests](https://github.com/killiansheriff/WarrenCowleyParameters/actions/workflows/python-tests.yml/badge.svg)
 
-> **Warning**
-> : As of version 1.0.0, you need to add ``import lovelyplots`` before setting the style (``plt.style.use('ipynb')``).
+> [!WARNING]
+> As of version 1.0.0, you need to add ``import lovelyplots`` before setting the style (``plt.style.use('ipynb')``).
 
 LovelyPlots is a repository containing ``matplotlib`` style sheets to nicely format figures for scientific papers, thesis and presentations while keeping them fully editable in ``Adobe Illustrator``. Additonaly, ``.svg`` exports options allows figures to automatically adapt their font to your document's font. For example, ``.svg`` figures imported in a ``.tex`` file will automatically be generated with the text font used in your ``.tex`` file.
 


### PR DESCRIPTION
I was trying to use the latest version of the package as I used to. But the style didn't take place. I checked the GitHub page of the project but I didn't notice any important hint in this regard, at first glance. So, I found the desaturated warning by scrutinizing the Readme.md. This PR changes the warning style to be more highlighted that hopefully better get attention.

Here is a preview of the result:
![Screenshot_20240305_102229_Samsung Internet](https://github.com/killiansheriff/LovelyPlots/assets/52105833/57717003-9d99-47cd-9a7f-ee2e7df31789)
